### PR TITLE
basic password security and lag fix

### DIFF
--- a/client.c
+++ b/client.c
@@ -6,6 +6,7 @@
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine, int iCmdShow) {
 	char szHost[256] = {0};;
 	char szPort[16] = {0};
+	char szPacket[32] = {0};
 	char szConfigFile[MAX_PATH] = {0};
 	if (GetCurrentDirectory(sizeof(szConfigFile), szConfigFile) == 0) {
 		MessageBox(NULL, "Failed to get the current working directory", "Error", MB_OK | MB_ICONERROR);
@@ -19,7 +20,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 		MessageBox(NULL, "Invalid or missing configuration file", "Error", MB_OK | MB_ICONERROR);
 		ExitProcess(1);
 	}
-	const char* szMessage = "kill";
+	if (GetPrivateProfileString("Settings", "Packet", NULL, szPacket, sizeof(szPacket), szConfigFile) == 0) {
+		strncpy(szPacket, "kill", sizeof(szPacket));
+	}
 	WSADATA wsaData;
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
 		MessageBox(NULL, "Failed to initialize Winsock", "Error", MB_OK | MB_ICONERROR);
@@ -47,7 +50,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 		WSACleanup();
 		ExitProcess(1);
 	}
-	if (send(hClientSocket, szMessage, strlen(szMessage), 0) == SOCKET_ERROR) {
+	if (send(hClientSocket, szPacket, strlen(szPacket), 0) == SOCKET_ERROR) {
 		MessageBox(NULL, "Failed to send data", "Error", MB_OK | MB_ICONERROR);
 	}
 	closesocket(hClientSocket);

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,4 @@
 [Settings]
 Host = 127.0.0.1
 Port = 5687
+Packet = NVDAKill

--- a/server.c
+++ b/server.c
@@ -40,6 +40,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 		ExitProcess(1);
 	}
 	char szPort[16] = {0};
+	char szPacket[32] = {0};
 	char szConfigFile[MAX_PATH] = {0};
 	if (GetCurrentDirectory(sizeof(szConfigFile), szConfigFile) == 0) {
 		MessageBox(NULL, "Failed to get the current working directory", "Error", MB_OK | MB_ICONERROR);
@@ -52,6 +53,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 	if (GetPrivateProfileString("Settings", "Port", NULL, szPort, sizeof(szPort), szConfigFile) == 0) {
 		MessageBox(NULL, "Invalid or missing configuration file", "Error", MB_OK | MB_ICONERROR);
 		ExitProcess(1);
+	}
+	if (GetPrivateProfileString("Settings", "Packet", NULL, szPacket, sizeof(szPacket), szConfigFile) == 0) {
+		strncpy(szPacket, "kill", sizeof(szPacket));
 	}
 	WSADATA wsaData;
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
@@ -82,6 +86,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 	}
 	MSG msg;
 	while (1) {
+		Sleep(5);
 		while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
 			if (msg.message == WM_QUIT) {
 				closesocket(hServerSocket);
@@ -108,7 +113,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 			int nBytesReceived;
 			while ((nBytesReceived = recv(hClientSocket, szBuffer, sizeof(szBuffer) - 1, 0)) > 0) {
 				szBuffer[nBytesReceived] = '\0';
-				if (strcmp(szBuffer, "kill") == 0) system("start nvda -r");
+				if (strcmp(szBuffer, szPacket) == 0) system("start nvda -r");
 			}
 			closesocket(hClientSocket);
 		}


### PR DESCRIPTION
Instead of the packet to kill NVDA just being "kill", it is now specified by the optional Packet key in config.ini. If the key doesn't exist, the packet defaults to kill. This allows for a sort of basic password security because you can now specify a custom packet nobody else knows.

Also in the server's while(1) loop, there was no Sleep or similar calls, causing the server to take 6 percent CPU. I added a Sleep(5) call to the top of that loop.

## Summary by Sourcery

Improves the application's security and reduces CPU usage. It introduces a configurable packet for the client-server communication, enhancing basic password security, and adds a sleep call in the server's main loop to reduce CPU load.

Enhancements:
- Introduces a configurable packet for client-server communication, enhancing basic password security by allowing users to specify a custom packet.
- Reduces CPU usage by adding a Sleep(5) call to the server's main loop.